### PR TITLE
Fixing issue with AmCharts filename error

### DIFF
--- a/export.js
+++ b/export.js
@@ -3134,9 +3134,7 @@ if ( !AmCharts.translations[ "export" ][ "en" ] ) {
 				_this.handleCallback( callback, "data", false );
 
 				// READY CALLBACK FOR EACH DEPENDENCY
-				for ( var filename in _this.libs.namespaces ) {
-					var namespace = _this.libs.namespaces[ filename ];
-
+				Object.values( _this.libs.namespaces ).forEach( function ( namespace ) {
 					( function( namespace ) {
 						var t1 = setInterval( function() {
 							var tsEnd = Number( new Date() );
@@ -3147,7 +3145,7 @@ if ( !AmCharts.translations[ "export" ][ "en" ] ) {
 							}
 						}, AmCharts.updateRate )
 					} )( namespace );
-				}
+				})
 			},
 
 			/**

--- a/export.js
+++ b/export.js
@@ -3134,7 +3134,8 @@ if ( !AmCharts.translations[ "export" ][ "en" ] ) {
 				_this.handleCallback( callback, "data", false );
 
 				// READY CALLBACK FOR EACH DEPENDENCY
-				Object.values( _this.libs.namespaces ).forEach( function ( namespace ) {
+				Object.keys(_this.libs.namespaces).forEach(function (key) {
+					var namespace = _this.libs.namespaces[key];
 					( function( namespace ) {
 						var t1 = setInterval( function() {
 							var tsEnd = Number( new Date() );
@@ -3145,7 +3146,7 @@ if ( !AmCharts.translations[ "export" ][ "en" ] ) {
 							}
 						}, AmCharts.updateRate )
 					} )( namespace );
-				})
+				});
 			},
 
 			/**


### PR DESCRIPTION
I'm build an app that wraps AmChart on a web component and export it on webpack. OK, I know AmChart was not meant to be used with webpack. Pretty much everything worked fine, except for this nasty error on console:

```
export.js?1994:3080 Uncaught ReferenceError: filename is not defined
    at Object.handleReady (export.js?1994:3080)
    at eval (export.js?1994:4216)
handleReady @ export.js?1994:3080
(anonymous) @ export.js?1994:4216
setInterval (async)
init @ export.js?1994:4197
construct @ export.js?1994:4340
AmCharts.export @ export.js?1994:4363
(anonymous) @ export.js?1994:4374
d.callInitHandler @ amcharts.js?7355:8
initChart @ amcharts.js?7355:115
initChart @ amcharts.js?7355:291
initChart @ [...obfuscated].min.js?0983:2025
initChart @ [...obfuscated].min.js?0983:2258
afterWrite @ amcharts.js?7355:115
write @ amcharts.js?7355:111
(anonymous) @ amcharts.js?7355:11
d.handleLoad @ amcharts.js?7355:7
localhost/:1 GET http://localhost:8080/__webpack_hmr net::ERR_INCOMPLETE_CHUNKED_ENCODING
```

In order to fix it, All I had to do was remove the forIn and replace it with a Object.keys.
Everything is working fine now.